### PR TITLE
Fix/standardize punctuation and capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ manipulation, class-type programming, events, promises, data stores, drag-and-dr
 
 ##Amazing Results in Less Time!
 
-Designing applications for the web is facilitated by the functionality dojo provides. Dojo offers plugins that a developer can employ to make writing javascript and AJAX more cross browser compliant. This will save you time and frustration. 
+Designing applications for the web is facilitated by the functionality Dojo provides. Dojo offers plugins that a developer can employ to make writing JavaScript and AJAX more cross-browser compliant. This will save you time and frustration. 
 
-If you want to add AJAX to your site, Ajax with Dojo will let you send and receive data without reloading the page. 
+If you want to add AJAX to your site, AJAX with Dojo will let you send and receive data without reloading the page. 
 
-If you want to create template based widgets, Dijit widgets offers a charting system that was designed to alleviate the pains of displaying dynamic data. 
+If you want to create template-based widgets, Dijit widgets offers a charting system that was designed to alleviate the pains of displaying dynamic data. 
 
 If you want to architect powerful web applications, Dojo's Core Concepts offers modular functionality to make it easier to author and debug code.
 


### PR DESCRIPTION
Couple more suggestions:

1st paragraph -- "to make writing JavaScript and AJAX more cross-browser compliant" - suggest splitting this into a broad point about JavaScript and a more specific point about AJAX. Seems odd to say you "write" AJAX as it is a specific method/technique as opposed to a programming language itself.

3rd paragraph -- Is Dojo "Core Concepts" the name of something specific or do you mean "core concepts" generically? (Couldn't find anything by this name)
